### PR TITLE
Hook up RockModel to Reservoir1D and add Discretizer (1D)

### DIFF
--- a/src/SimpleReservoirSimulator/Discretizer/Discretizer.cpp
+++ b/src/SimpleReservoirSimulator/Discretizer/Discretizer.cpp
@@ -1,0 +1,17 @@
+#include "Discretizer.h"
+
+void Discretizer::ComputeTransmissibility(std::vector<double>& permeability, double cellArea, double cellWidthXDir, std::vector<double>& transmissibilityTarget)
+{
+	double cellInterfacePermeability;
+	for (int i = 1; i < permeability.size(); i++)
+	{
+		cellInterfacePermeability = ComputeInterfacePermeability(permeability[i - 1], permeability[i]);
+		transmissibilityTarget[i] = cellInterfacePermeability * cellArea / cellWidthXDir;
+	}
+}
+
+double Discretizer::ComputeInterfacePermeability(double& permeabilityLeft, double& permeabilityRight)
+{
+	double cellInterfacePermeability = 2 * permeabilityLeft * permeabilityRight;
+	return  cellInterfacePermeability / (permeabilityLeft + permeabilityRight);
+}

--- a/src/SimpleReservoirSimulator/Discretizer/Discretizer.h
+++ b/src/SimpleReservoirSimulator/Discretizer/Discretizer.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <vector>
+
+class Discretizer
+{
+public:
+	static void ComputeTransmissibility(std::vector<double>& permeability, double cellArea, double cellWidthXDir, std::vector<double>& transmissibilityTarget);
+
+private:
+	static double ComputeInterfacePermeability(double& permeabilityLeft, double& permeabilityRight);
+};
+

--- a/src/SimpleReservoirSimulator/Reservoir/Reservoir1D.h
+++ b/src/SimpleReservoirSimulator/Reservoir/Reservoir1D.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <vector>
+#include "../RockModel/RockModel.h"
+#include "../Discretizer/Discretizer.h"
 
 /// <summary>
 /// One dimensional reservoir class, suited for Finite Volume discretization. Unkowns are located at the cell centers.
@@ -35,13 +37,19 @@ public:
 
 	std::vector<double> PositionCellCenterXDir;
 	std::vector<double> PositionCellInterfaceXDir;
+	std::vector<double> ReservoirPermeability;
+	std::vector<double> ReservoirTransmissibility;
 
-	Reservoir1D();
-	Reservoir1D(int numberOfCellsXDir, double reservoirLengthXDir, double reservoirLengthYDir, double reservoirHeightZDir, double cellWidthXDir);
+	Reservoir1D(RockModel rockModel);
+	Reservoir1D(int numberOfCellsXDir, double reservoirLengthXDir, double reservoirLengthYDir, double reservoirHeightZDir, double cellWidthXDir, RockModel rockModel);
 
 	void ComputeGeometry();
+	void SetConstantReservoirPermeability();
+	void SetHeterogeneousReservoirPermeability(std::vector<double> permeability);
+	void DiscretizeReservoir();
 
 private:
 	void Init();
+	RockModel _rockModel;
 };
 

--- a/src/SimpleReservoirSimulator/SimpleReservoirSimulator.vcxproj
+++ b/src/SimpleReservoirSimulator/SimpleReservoirSimulator.vcxproj
@@ -129,6 +129,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="Discretizer\Discretizer.cpp" />
     <ClCompile Include="PhysicsModel\PhysicsModel.cpp" />
     <ClCompile Include="PhysicsModel\Density\Density.cpp" />
     <ClCompile Include="Reservoir\Reservoir1D.cpp" />
@@ -141,6 +142,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Discretizer\Discretizer.h" />
     <ClInclude Include="PhysicsModel\PhysicsModel.h" />
     <ClInclude Include="PhysicsModel\Density\Density.h" />
     <ClInclude Include="Reservoir\Reservoir1D.h" />

--- a/src/SimpleReservoirSimulator/SimpleReservoirSimulator.vcxproj.filters
+++ b/src/SimpleReservoirSimulator/SimpleReservoirSimulator.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClCompile Include="Solver\Solver.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Discretizer\Discretizer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -57,6 +60,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Solver\Solver.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Discretizer\Discretizer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/SimpleReservoirSimulatorTests/Discretizer/DiscretizerTests.cpp
+++ b/src/SimpleReservoirSimulatorTests/Discretizer/DiscretizerTests.cpp
@@ -1,0 +1,23 @@
+#include "../pch.h"
+#include "../../SimpleReservoirSimulator/Discretizer/Discretizer.cpp"
+#include <vector>
+
+namespace DiscretizerTests {
+	TEST(ComputeTransmissibility, Executed_CorrectTransmissibilities) {
+		// Assert
+		std::vector<double> permeability = { 1.0, 2.0, 2.0, 0.5 };
+		double cellArea = 1.0;
+		double cellWidthXDir = 0.5;
+		std::vector<double> expectedTransmissibility = { 0, 8.0/3.0, 4, 1.6, 0 };
+		
+		// Act
+		std::vector<double> transmissibility(permeability.size() + 1);
+		Discretizer::ComputeTransmissibility(permeability, cellArea, cellWidthXDir, transmissibility);
+
+		// Assert
+		for (int i = 0; i < expectedTransmissibility.size(); i++)
+		{
+			EXPECT_DOUBLE_EQ(transmissibility[i], expectedTransmissibility[i]);
+		}
+	}
+}

--- a/src/SimpleReservoirSimulatorTests/Reservoir/Reservoir1DTests.cpp
+++ b/src/SimpleReservoirSimulatorTests/Reservoir/Reservoir1DTests.cpp
@@ -2,12 +2,12 @@
 #include "../../SimpleReservoirSimulator/Reservoir/Reservoir1D.cpp"
 
 namespace Reservoir1DTests {
-	static TEST(ComputeGeometry, Executed_CellAndInterfacePosSet) {
+	TEST(ComputeGeometry, Executed_CellAndInterfacePosSet) {
 		// Arrange
 		int numberOfCells = 10;
 		double widthCellXDir = 1.0;
 		double lengthReservoir = numberOfCells * widthCellXDir;
-		Reservoir1D sut = Reservoir1D(numberOfCells, lengthReservoir, 1.0, 1.0, widthCellXDir);
+		Reservoir1D sut = Reservoir1D(numberOfCells, lengthReservoir, 1.0, 1.0, widthCellXDir, RockModel());
 
 		// Act
 		sut.ComputeGeometry();
@@ -24,9 +24,9 @@ namespace Reservoir1DTests {
 		EXPECT_DOUBLE_EQ(sut.PositionCellInterfaceXDir[numberOfCells], 10.0);
 	}
 
-	static TEST(Constructor, ObjectConstructed_MemberVariablesNotNull) {
+	TEST(Constructor, ObjectConstructed_MemberVariablesNotNull) {
 		// Arrange && Act
-		Reservoir1D sut = Reservoir1D();
+		Reservoir1D sut = Reservoir1D(RockModel());
 
 		// Assert
 		EXPECT_TRUE(sut.CellArea != NULL);

--- a/src/SimpleReservoirSimulatorTests/SimpleReservoirSimulatorTests.vcxproj
+++ b/src/SimpleReservoirSimulatorTests/SimpleReservoirSimulatorTests.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{502970f1-bd9c-4567-bf73-c4b4544ce0a0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/src/SimpleReservoirSimulatorTests/SimpleReservoirSimulatorTests.vcxproj
+++ b/src/SimpleReservoirSimulatorTests/SimpleReservoirSimulatorTests.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{502970f1-bd9c-4567-bf73-c4b4544ce0a0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -100,6 +100,7 @@
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Discretizer\DiscretizerTests.cpp" />
     <ClCompile Include="pch.cpp" />
     <ClCompile Include="PhysicsModel\Density\DensityTests.cpp" />
     <ClCompile Include="PhysicsModel\Viscosity\ViscosityTests.cpp" />


### PR DESCRIPTION
## Description
Fill ReservoirPermeability based on RockModel constant permeability or permeability vector (will be read from a file in the future). Add a discretizer that discretizes the 1D reservoir to get interface transmissibilities (only geometric since incompressible single phase) based on constant interfaceArea and distance between interfaces.

### DevOps work item
...

## Critical changes
Reservoir1D now contains RockModel and can be discretized based on geometry and reservoir permeability.

## Additional info
- [x] Does your PR include unit-tests
