### PR TITLE
Add missing documentation, Simulation Case class and update entry point app

### DIFF
--- a/src/SimpleReservoirSimulator/Discretizer/Discretizer.cpp
+++ b/src/SimpleReservoirSimulator/Discretizer/Discretizer.cpp
@@ -1,5 +1,12 @@
 #include "Discretizer.h"
 
+/// <summary>
+/// Computes interface transmissibility
+/// </summary>
+/// <param name="permeability">Reservoir permeability in mDarcy</param>
+/// <param name="cellArea">(constant) interface area in m2</param>
+/// <param name="cellWidthXDir">(constant) cellWidth in the x-direction</param>
+/// <param name="transmissibilityTarget">target vector to store transmissibility values</param>
 void Discretizer::ComputeTransmissibility(std::vector<double>& permeability, double cellArea, double cellWidthXDir, std::vector<double>& transmissibilityTarget)
 {
 	double cellInterfacePermeability;
@@ -10,6 +17,12 @@ void Discretizer::ComputeTransmissibility(std::vector<double>& permeability, dou
 	}
 }
 
+/// <summary>
+/// Compute interface permeability based on harmonic average
+/// </summary>
+/// <param name="permeabilityLeft">permeablity left cell in mDarcy</param>
+/// <param name="permeabilityRight">permeability right cell in mDarcy</param>
+/// <returns>interface permeability in mDarcy</returns>
 double Discretizer::ComputeInterfacePermeability(double& permeabilityLeft, double& permeabilityRight)
 {
 	double cellInterfacePermeability = 2 * permeabilityLeft * permeabilityRight;

--- a/src/SimpleReservoirSimulator/Reservoir/Reservoir1D.cpp
+++ b/src/SimpleReservoirSimulator/Reservoir/Reservoir1D.cpp
@@ -31,11 +31,18 @@ void Reservoir1D::ComputeGeometry()
     }
 }
 
+/// <summary>
+/// Assign constant permeability to each cell based on RockModel.permeability
+/// </summary>
 void Reservoir1D::SetConstantReservoirPermeability()
 {
     std::fill(ReservoirPermeability.begin(), ReservoirPermeability.end(), _rockModel.permeability);
 }
 
+/// <summary>
+/// Assign (potential) non-constant permeability to each cell in the reservoir, could be read from file... (in the future)
+/// </summary>
+/// <param name="permeability"></param>
 void Reservoir1D::SetHeterogeneousReservoirPermeability(std::vector<double> permeability)
 {
     if (permeability.size() != ReservoirPermeability.size())
@@ -45,6 +52,9 @@ void Reservoir1D::SetHeterogeneousReservoirPermeability(std::vector<double> perm
     ReservoirPermeability.assign(permeability.begin(), permeability.end());
 }
 
+/// <summary>
+/// Discretize reservoir based on set permeability and geometry
+/// </summary>
 void Reservoir1D::DiscretizeReservoir()
 {
     Discretizer::ComputeTransmissibility(ReservoirPermeability, CellArea, CellWidthXDir, ReservoirTransmissibility);

--- a/src/SimpleReservoirSimulator/RockModel/RockModel.cpp
+++ b/src/SimpleReservoirSimulator/RockModel/RockModel.cpp
@@ -11,6 +11,11 @@ RockModel::RockModel(double referencePorosity, double referencePressure, double 
 {
 }
 
+/// <summary>
+/// Compute porosity based on pressure
+/// </summary>
+/// <param name="pressure">Reservoir fluid pressure in Pa</param>
+/// <returns>Porosity (dimensionless)</returns>
 double RockModel::ComputePorosity(double pressure)
 {
 	assert(pressure > 0);

--- a/src/SimpleReservoirSimulator/SimpleReservoirSimulator.cpp
+++ b/src/SimpleReservoirSimulator/SimpleReservoirSimulator.cpp
@@ -23,11 +23,12 @@ int main()
     simulationCase.SolveSingleIteration();
 
     std::cout << "Pressure in reservoir, p = \n";
-    for (int i = 0; i < solver.Solution.size(); i++)
+    for (int i = 0; i < simulationCase.IncompressibleSinglePhase1DSolver.Solution.size(); i++)
     {
-        std::cout << solver.Solution[i] << "\n";
+        std::cout << simulationCase.IncompressibleSinglePhase1DSolver.Solution[i] << "\n";
     }
     std::cout << std::endl;
 
+    std::cout << "Press enter key to continue...";
     std::cin.get();
 }

--- a/src/SimpleReservoirSimulator/SimpleReservoirSimulator.cpp
+++ b/src/SimpleReservoirSimulator/SimpleReservoirSimulator.cpp
@@ -1,20 +1,33 @@
 // SimpleReservoirSimulator.cpp : This file contains the 'main' function. Program execution begins and ends there.
 //
-
 #include <iostream>
+#include "SimulationCase/SimulationCase.h"
 
 int main()
 {
-    std::cout << "Hello World!\n";
+    std::cout << "Start program: Simple 1D reservoir simulator for single phase flow" << std::endl;
+
+    std::cout << "Construct physics object" << std::endl;
+    PhysicsModel physics = PhysicsModel();
+
+    std::cout << "Construct reservoir object" << std::endl;
+    Reservoir1D reservoir = Reservoir1D(RockModel());
+    reservoir.SetConstantReservoirPermeability();
+
+    std::cout << "Setup linear solver" << std::endl;
+    Solver solver = Solver(reservoir.NumberOfCellsXDir);
+
+    std::cout << "Create simple simulation case" << std::endl;
+    SimulationCase simulationCase = SimulationCase(reservoir, physics, solver);
+    simulationCase.SetupBasicSimulationCase();
+    simulationCase.SolveSingleIteration();
+
+    std::cout << "Pressure in reservoir, p = \n";
+    for (int i = 0; i < solver.Solution.size(); i++)
+    {
+        std::cout << solver.Solution[i] << "\n";
+    }
+    std::cout << std::endl;
+
+    std::cin.get();
 }
-
-// Run program: Ctrl + F5 or Debug > Start Without Debugging menu
-// Debug program: F5 or Debug > Start Debugging menu
-
-// Tips for Getting Started: 
-//   1. Use the Solution Explorer window to add/manage files
-//   2. Use the Team Explorer window to connect to source control
-//   3. Use the Output window to see build output and other messages
-//   4. Use the Error List window to view errors
-//   5. Go to Project > Add New Item to create new code files, or Project > Add Existing Item to add existing code files to the project
-//   6. In the future, to open this project again, go to File > Open > Project and select the .sln file

--- a/src/SimpleReservoirSimulator/SimpleReservoirSimulator.vcxproj
+++ b/src/SimpleReservoirSimulator/SimpleReservoirSimulator.vcxproj
@@ -136,6 +136,7 @@
     <ClCompile Include="RockModel\RockModel.cpp" />
     <ClCompile Include="SimpleReservoirSimulator.cpp" />
     <ClCompile Include="PhysicsModel\Viscosity\Viscosity.cpp" />
+    <ClCompile Include="SimulationCase\SimulationCase.cpp" />
     <ClCompile Include="Solver\Solver.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -148,6 +149,7 @@
     <ClInclude Include="Reservoir\Reservoir1D.h" />
     <ClInclude Include="PhysicsModel\Viscosity\Viscosity.h" />
     <ClInclude Include="RockModel\RockModel.h" />
+    <ClInclude Include="SimulationCase\SimulationCase.h" />
     <ClInclude Include="Solver\Solver.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/SimpleReservoirSimulator/SimpleReservoirSimulator.vcxproj.filters
+++ b/src/SimpleReservoirSimulator/SimpleReservoirSimulator.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClCompile Include="Discretizer\Discretizer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="SimulationCase\SimulationCase.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -63,6 +66,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Discretizer\Discretizer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="SimulationCase\SimulationCase.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/SimpleReservoirSimulator/SimulationCase/SimulationCase.cpp
+++ b/src/SimpleReservoirSimulator/SimulationCase/SimulationCase.cpp
@@ -1,0 +1,6 @@
+#include "SimulationCase.h"
+
+SimulationCase::SimulationCase(Reservoir1D reservoir, PhysicsModel physics, Solver solver) :
+	Reservoir(reservoir), Physics(physics), IncompressibleSinglePhase1DSolver(solver)
+{
+}

--- a/src/SimpleReservoirSimulator/SimulationCase/SimulationCase.cpp
+++ b/src/SimpleReservoirSimulator/SimulationCase/SimulationCase.cpp
@@ -4,3 +4,18 @@ SimulationCase::SimulationCase(Reservoir1D reservoir, PhysicsModel physics, Solv
 	Reservoir(reservoir), Physics(physics), IncompressibleSinglePhase1DSolver(solver)
 {
 }
+
+void SimulationCase::SetupBasicSimulationCase()
+{
+	// Discretize Reservoir:
+	Reservoir.DiscretizeReservoir();
+
+	// Setup linear system:
+	IncompressibleSinglePhase1DSolver.FillInnerDomainLinearSystem(Reservoir.ReservoirTransmissibility);
+	IncompressibleSinglePhase1DSolver.SetStandardBoundaryConditions(1.0, 0.0);
+}
+
+void SimulationCase::SolveSingleIteration()
+{
+	IncompressibleSinglePhase1DSolver.SolveLinearSystem();
+}

--- a/src/SimpleReservoirSimulator/SimulationCase/SimulationCase.h
+++ b/src/SimpleReservoirSimulator/SimulationCase/SimulationCase.h
@@ -11,5 +11,8 @@ public:
 	Solver IncompressibleSinglePhase1DSolver;
 
 	SimulationCase(Reservoir1D reservoir, PhysicsModel physics, Solver solver);
+
+	void SetupBasicSimulationCase();
+	void SolveSingleIteration();
 };
 

--- a/src/SimpleReservoirSimulator/SimulationCase/SimulationCase.h
+++ b/src/SimpleReservoirSimulator/SimulationCase/SimulationCase.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "../Reservoir/Reservoir1D.h"
+#include "../PhysicsModel/PhysicsModel.h"
+#include "../Solver/Solver.h"
+
+class SimulationCase
+{
+public:
+	Reservoir1D Reservoir;
+	PhysicsModel Physics;
+	Solver IncompressibleSinglePhase1DSolver;
+
+	SimulationCase(Reservoir1D reservoir, PhysicsModel physics, Solver solver);
+};
+

--- a/src/SimpleReservoirSimulator/Solver/Solver.h
+++ b/src/SimpleReservoirSimulator/Solver/Solver.h
@@ -6,6 +6,7 @@ class Solver
 {
 public:
 	Solver(int numberOfUnknowns);
+
 	/// <summary>
 	/// Contains the solution to Ax = b (A = connectivity matrix with transmissibility as coefficient, and b is source terms, while x = pressure)
 	/// </summary>


### PR DESCRIPTION
## Description
Add missing documentation for Discretizer, Reservoir1D, and RockModel. Add a SimulationCase class combines all necessary elements for simulation: a reservoir, physics, and a solver. Physics is currently under uttilized, since all properties are assumed constant (viscosity and density, also porosity, therefore pressure profile is only affected by permeability distribution and reservoir geometry), but will be used in the future when a slightly compressible flow solver is added. The simulation case discretized the reservoir and setups up the linear system, it also has a wrapper to perform a single solve of the linear system. The entry point of the app is changed in such a way that it runs the most basic solution imaginable.

### DevOps work item
...

## Critical changes
Missing documentation, SimulationCase class which combines the necessary components for a simulation, and the entry point of the app now runs the most basic simulation case.

TODO: In next PR add unit-tests for new class and integration test for larger reservoir model.

## Additional info
- [ ] Does your PR include unit-tests
